### PR TITLE
gdb 14.2 [linux]

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -73,11 +73,6 @@ $SRC_DIR/configure \
     --with-libiconv-prefix=$PREFIX \
     ${expat_flag:-} \
     || (cat config.log && exit 1)
-# Force all generated Makefiles to use MAKEINFO=true so submakes (bfd, etc.) don't run makeinfo.
-# Configure bakes MAKEINFO path into Makefiles; env/command-line don't propagate to all submakes.
-for f in $(find . -name Makefile); do
-  sed -i.bak 's/^MAKEINFO *=.*/MAKEINFO = true/' "$f" || true
-done
+
 make -j${CPU_COUNT} VERBOSE=1
 make install
-

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -60,10 +60,6 @@ export CXXFLAGS="${CXXFLAGS} -std=gnu++17"
 mkdir build
 cd build
 
-# Disable building .info docs to avoid Perl/texinfo ABI mismatch (e.g. pl526 vs system Perl).
-# Set before configure so generated Makefiles get it; pass to make so submakes inherit it.
-export MAKEINFO=true
-
 $SRC_DIR/configure \
     --prefix="$PREFIX" \
     --with-separate-debug-dir="$PREFIX/lib/debug:/usr/lib/debug" \
@@ -74,5 +70,5 @@ $SRC_DIR/configure \
     ${expat_flag:-} \
     || (cat config.log && exit 1)
 
-make -j${CPU_COUNT} VERBOSE=1
+make VERBOSE=2
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,9 +32,7 @@ end
 ' >> "$PREFIX/etc/gdbinit"
 
 # macOS specificities
-if [[ $target_platform == "osx-64" ]]; then
-  # prevent a VERSION file being confused by clang++ with $CONDA_PREFIX/include/c++/v1/version
-  mv intl/VERSION intl/VERSION.txt
+if [[ $target_platform == "osx-*" ]]; then
   # install needed scripts to generate a codesigning certificate and sign the gdb executable
   cp $RECIPE_DIR/macos-codesign/macos-setup-codesign.sh $PREFIX/bin/
   cp $RECIPE_DIR/macos-codesign/macos-codesign-gdb.sh   $PREFIX/bin/
@@ -67,7 +65,8 @@ $SRC_DIR/configure \
     --with-separate-debug-dir="$PREFIX/lib/debug:/usr/lib/debug" \
     --with-python=${PYTHON} \
     --with-system-gdbinit="$PREFIX/etc/gdbinit" \
-    ${libiconv_flag:-} \
+    --with-system-zlib \
+    --with-libiconv-prefix=$PREFIX \
     ${expat_flag:-} \
     || (cat config.log && exit 1)
 make -j${CPU_COUNT} VERBOSE=1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -70,5 +70,5 @@ $SRC_DIR/configure \
     ${expat_flag:-} \
     || (cat config.log && exit 1)
 
-make VERBOSE=2
+make -j${CPU_COUNT} VERBOSE=1
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -60,6 +60,10 @@ export CXXFLAGS="${CXXFLAGS} -std=gnu++17"
 mkdir build
 cd build
 
+# Disable building .info docs to avoid Perl/texinfo ABI mismatch (e.g. pl526 vs system Perl).
+# Set before configure so generated Makefiles get it; pass to make so submakes inherit it.
+export MAKEINFO=true
+
 $SRC_DIR/configure \
     --prefix="$PREFIX" \
     --with-separate-debug-dir="$PREFIX/lib/debug:/usr/lib/debug" \
@@ -69,8 +73,11 @@ $SRC_DIR/configure \
     --with-libiconv-prefix=$PREFIX \
     ${expat_flag:-} \
     || (cat config.log && exit 1)
-# Disable building .info docs to avoid Perl/texinfo ABI mismatch (e.g. pl526 vs system Perl)
-export MAKEINFO=true
+# Force all generated Makefiles to use MAKEINFO=true so submakes (bfd, etc.) don't run makeinfo.
+# Configure bakes MAKEINFO path into Makefiles; env/command-line don't propagate to all submakes.
+for f in $(find . -name Makefile); do
+  sed -i.bak 's/^MAKEINFO *=.*/MAKEINFO = true/' "$f" || true
+done
 make -j${CPU_COUNT} VERBOSE=1
 make install
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -69,6 +69,8 @@ $SRC_DIR/configure \
     --with-libiconv-prefix=$PREFIX \
     ${expat_flag:-} \
     || (cat config.log && exit 1)
+# Disable building .info docs to avoid Perl/texinfo ABI mismatch (e.g. pl526 vs system Perl)
+export MAKEINFO=true
 make -j${CPU_COUNT} VERBOSE=1
 make install
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [not linux]
+  # py==313: GDB 14.2 uses _PyOS_ReadlineTState (removed in Python 3.13 C API)
+  skip: true  # [not linux or py==313]
   script_env:
     - TMPDIR
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ requirements:
     - xz {{ xz }}
     - zlib {{ zlib }}
     - readline {{ readline }}
-    - libiconv {{ libiconv }} # [osx]
-    - expat {{ expat }}
+    - libiconv {{ libiconv }}  # [osx]
+    - libexpat {{ libexpat }}
     - gmp {{ gmp }}
     - mpfr {{ mpfr }}
   run:
@@ -49,8 +49,8 @@ requirements:
     - xz
     - zlib
     - six
-    - libiconv
-    - expat
+    - libiconv  # [osx]
+    - libexpat
     - pygments
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,8 @@ requirements:
     - {{ cdt('libxcrypt-devel') }}  # [py<311]
   host:
     - python
+    # match texinfo's pl526 build (avoid makeinfo Perl XS ABI mismatch)
+    - perl =5.26.*
     - ncurses {{ ncurses }}
     - texinfo 6.5
     - xz {{ xz }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,8 @@ source:
 
 build:
   number: 0
-  # py==313: GDB 14.2 uses _PyOS_ReadlineTState (removed in Python 3.13 C API)
-  skip: true  # [not linux or py==313]
+  # GDB 14.2 uses _PyOS_ReadlineTState (removed in Python 3.13 C API)
+  skip: true  # [not linux or py<310 or py>312]
   script_env:
     - TMPDIR
 
@@ -39,7 +39,7 @@ requirements:
     - xz {{ xz }}
     - zlib {{ zlib }}
     - readline {{ readline }}
-    - libiconv {{ libiconv }}
+    - libiconv {{ libiconv }} # [osx]
     - expat {{ expat }}
     - gmp {{ gmp }}
     - mpfr {{ mpfr }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,15 @@ package:
   version: {{ version }}
 
 source:
-  url: https://ftp.gnu.org/gnu/gdb/gdb-{{ version }}.tar.xz
+  url:
+    - https://ftp.gnu.org/gnu/gdb/gdb-{{ version }}.tar.xz
+    - https://mirrors.ocf.berkeley.edu/gnu/gdb/gdb-{{ version }}.tar.xz
   sha256: 2d4dd8061d8ded12b6c63f55e45344881e8226105f4d2a9b234040efa5ce7772
   patches:
 
 build:
   number: 0
-  skip: true  # [win]
-  # needed by macOS codesigning script
+  skip: true  # [not linux]
   script_env:
     - TMPDIR
 
@@ -21,33 +22,38 @@ requirements:
   build:
     - {{ compiler('fortran') }}
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - make >=3.82
-    - sysroot_linux-64 2.17  # [linux64]
+    # python .../python-config.py --ldflags report -lcrypt for 3.9 and
+    # 3.10 which is subsequently used during configure and later
+    # during make. libcrypt-devel has the libcrypt.so itself
+    - {{ cdt('libxcrypt-devel') }}  # [py<311]
   host:
     - python
-    - ncurses
-    - texinfo
-    - xz
-    - zlib
-    - readline
-    - libiconv  # [osx]
-    - expat     # [osx]
-    - gmp
-    - mpfr
+    - ncurses {{ ncurses }}
+    - texinfo 6.5
+    - xz {{ xz }}
+    - zlib {{ zlib }}
+    - readline {{ readline }}
+    - libiconv {{ libiconv }}
+    - expat {{ expat }}
+    - gmp {{ gmp }}
+    - mpfr {{ mpfr }}
   run:
     - python
     - ncurses
     - xz
     - zlib
     - six
-    - libiconv  # [osx]
-    - expat     # [osx]
+    - libiconv
+    - expat
     - pygments
 
 test:
   commands:
-    - gdb --version
+    - $PREFIX/bin/gdb --version
+    - $PREFIX/bin/gdb -q -ex "show host-charset" --batch
   requires:
     - {{ compiler('c') }}
 
@@ -66,7 +72,7 @@ about:
     same machine as GDB (native) or on another machine (remote).
     GDB can run on most popular UNIX and Microsoft Windows variants.
   doc_url: https://sourceware.org/gdb/current/onlinedocs/gdb/
-  dev_url: git://sourceware.org/git/binutils-gdb.git
+  dev_url: https://sourceware.org/git/binutils-gdb.git
 
 extra:
   recipe-maintainers:

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+# Only run macOS-specific logic on Darwin; exit successfully on Linux and other platforms
+if [[ $(uname) != "Darwin" ]]; then
+  exit 0
+fi
+
 # Returns 0 if current user is in the sudoers file
 # and sudo-ing does not require a password.
 can_sudo_without_password () {

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -12,11 +12,15 @@ fi
 # Check source code highlighting works (using Pygments)
 gdb -ex "show style sources" -batch | grep "enabled"
 
-# Run hello world test
-if [[ $(uname) != "Darwin" ]]; then # skip test for now, as it hangs on Azure's 10.15 image
-  $CC -o hello -g "$RECIPE_DIR/testing/hello.c"
-  gdb -batch -ex "run" --args hello
+if [[ $(uname -m) == "ppc64le" || $(uname -m) == "aarch64" ]]; then
+  # Emulated docker images do not provide sufficient support for gdb
+  # https://github.com/docker/for-mac/issues/5191
+  exit 0
 fi
+
+# Run hello world test
+$CC -o hello -g "$RECIPE_DIR/testing/hello.c"
+gdb -batch -ex "run" --args hello
 
 # This next test tries to simulate a crash on a python process. The process under test
 # forces a crash by emitting a SIGSEGV signal to itself. This is similar to what
@@ -63,7 +67,7 @@ gdb -batch -ex "run" -ex "py-bt" --args python "$RECIPE_DIR/testing/process_to_d
 # debugged out-of-the-box with this gdb package. When things change, there is not much to be
 # done besides adding or removing versions from this list.
 # Example: insufficient_debug_info_versions=("27" "37")
-insufficient_debug_info_versions=("312")
+insufficient_debug_info_versions=("312" "313")
 
 if [[ " ${insufficient_debug_info_versions[@]} " =~ " ${CONDA_PY} " ]]; then
     if grep "line 3" gdb_output; then

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -12,12 +12,6 @@ fi
 # Check source code highlighting works (using Pygments)
 gdb -ex "show style sources" -batch | grep "enabled"
 
-if [[ $(uname -m) == "ppc64le" || $(uname -m) == "aarch64" ]]; then
-  # Emulated docker images do not provide sufficient support for gdb
-  # https://github.com/docker/for-mac/issues/5191
-  exit 0
-fi
-
 # Run hello world test
 $CC -o hello -g "$RECIPE_DIR/testing/hello.c"
 gdb -batch -ex "run" --args hello


### PR DESCRIPTION
gdb 14.2 (linux only)

[PKG-12721](https://anaconda.atlassian.net/browse/PKG-12721)

Explanation of changes:
- downgrade to required version 14.2 (for `linux` only)
- sync with newest feedstock changes
- downgrade `perl` to avoid ABI incompatibility

[PKG-12721]: https://anaconda.atlassian.net/browse/PKG-12721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ